### PR TITLE
Use RegEx in handelTest registration to allow query test and usage …

### DIFF
--- a/main/ESP32Explorer.cpp
+++ b/main/ESP32Explorer.cpp
@@ -538,8 +538,8 @@ void ESP32_Explorer::start() {
 	  * Create a WebServer and register handlers for REST requests.
 	  */
 	 HttpServer* pHttpServer = new HttpServer();
-	 pHttpServer->setRootPath("/spiflash");
-	 pHttpServer->addPathHandler("GET",    "/hello",      		           handleTest);
+	 std::regex TestPath("\\/hello.*");
+	 pHttpServer->addPathHandler("GET",    &TestPAth,      		           handleTest);
 	 pHttpServer->addPathHandler("GET",    "/ESP32/WIFI",                  handle_REST_WiFi);
 	 pHttpServer->addPathHandler("GET",    "/ESP32/I2S",                   handle_REST_I2S);
 	 pHttpServer->addPathHandler("GET",    "/ESP32/GPIO",                  handle_REST_GPIO);

--- a/main/ESP32Explorer.cpp
+++ b/main/ESP32Explorer.cpp
@@ -539,7 +539,7 @@ void ESP32_Explorer::start() {
 	  */
 	 HttpServer* pHttpServer = new HttpServer();
 	 std::regex TestPath("\\/hello.*");
-	 pHttpServer->addPathHandler("GET",    &TestPAth,      		           handleTest);
+	 pHttpServer->addPathHandler("GET",    &TestPath,      		           handleTest);
 	 pHttpServer->addPathHandler("GET",    "/ESP32/WIFI",                  handle_REST_WiFi);
 	 pHttpServer->addPathHandler("GET",    "/ESP32/I2S",                   handle_REST_I2S);
 	 pHttpServer->addPathHandler("GET",    "/ESP32/GPIO",                  handle_REST_GPIO);


### PR DESCRIPTION
Since handleTest request handler is also parsing and logging the query params, the implementation of the handler registration could allow this.
For this we need to call "addPathHandler" method in it's &RegEx form.